### PR TITLE
Correção do for do método next da classe Troco

### DIFF
--- a/Source Code Inspection/src/br/calebe/ticketmachine/core/Troco.java
+++ b/Source Code Inspection/src/br/calebe/ticketmachine/core/Troco.java
@@ -75,7 +75,7 @@ class Troco {
         @Override
         public PapelMoeda next() {
             PapelMoeda ret = null;
-            for (int i = troco.papeisMoeda.length-1; i >= 0 && ret != null; i--) {
+            for (int i = troco.papeisMoeda.length-1; i >= 0 && ret == null; i--) {
                 if (troco.papeisMoeda[i] != null) {
                     ret = troco.papeisMoeda[i];
                     troco.papeisMoeda[i] = null;


### PR DESCRIPTION
O for do método next() ele não entra por uma das condições do for estar com a variável ret != null sendo que o certo é == null